### PR TITLE
Stop container gracefully

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,4 +17,4 @@ chown yarr:yarr $DATA
 
 # Start the server as the yarr user
 echo "Starting yarr as $UID:$GID..."
-su-exec yarr:yarr /home/yarr/yarr -addr "$ADDRESS:$PORT" -db "$DATA/yarr.db"
+exec su-exec yarr:yarr /home/yarr/yarr -addr "$ADDRESS:$PORT" -db "$DATA/yarr.db"


### PR DESCRIPTION
When stopping the container, Docker sends a SIGTERM signal to the entrypoint shell process, but the signal is ignored. After a grace period of 10 seconds Docker sends a SIGKILL signal, which can't be ignored, and finally yarr is killed.

This patch fixes this problem by replacing the entrypoint process with the yarr process, using "exec".